### PR TITLE
Rename config.sample.toml config.toml when running

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:20.04
 WORKDIR /app
 COPY nomad-events-sink.bin .
-COPY config.sample.toml .
+COPY config.sample.toml ./config.toml
 CMD ["./nomad-events-sink.bin"]

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -21,7 +21,7 @@ func main() {
 	ctx, _ := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 
 	// Initialise and load the config.
-	ko, err := initConfig("config.sample.toml", "NOMAD_EVENTS_SINK_")
+	ko, err := initConfig("config.toml", "NOMAD_EVENTS_SINK_")
 	if err != nil {
 		fmt.Println("error initialising config", err)
 		os.Exit(1)


### PR DESCRIPTION
In the repo it makes sense to present the config file as a sample or default config, however when templating a config file running in production, the sample designator doesn't make sense.

This patch will rename it to `config.toml` within the Dockerfile and instead load from `config.toml` within the main function.

Alternatives considered:
* Renaming to `config.default.toml`
* Providing a command line argument containing a path (This would be in addition to the rename"