### PR TITLE
Make Prepare a method of a Provider

### DIFF
--- a/internal/sinks/provider/http.go
+++ b/internal/sinks/provider/http.go
@@ -2,10 +2,12 @@ package provider
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
 
+	"github.com/hashicorp/nomad/api"
 	"github.com/sirupsen/logrus"
 )
 
@@ -61,6 +63,15 @@ func NewHTTP(opts HTTPOpts) (*HTTPManager, error) {
 	}
 
 	return httpMgr, nil
+}
+
+// Prepare takes batches of events and returns JSON encoding of the same.
+func (m *HTTPManager) Prepare(events []api.Event) ([]byte, error) {
+	data, err := json.Marshal(events)
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
 }
 
 // Push sends out events to an HTTP Endpoint.

--- a/internal/sinks/provider/provider.go
+++ b/internal/sinks/provider/provider.go
@@ -1,8 +1,12 @@
 package provider
 
+import "github.com/hashicorp/nomad/api"
+
 type Provider interface {
 	// Name returns the name of the Provider.
 	Name() string
+	// Prepare returns a prepared payload as an array of bytes
+	Prepare([]api.Event) ([]byte, error)
 	// Push pushes a batch of event to upstream. The implementation varies across providers.
 	Push([]byte) error
 	// Ping implements a healthcheck.


### PR DESCRIPTION
The event perparation is opinioned and suitable only for the HTTP Provider. Another provider that would use a different format (eg. Loki) would require deserializing the JSON back to `[]api.Event` and then serializing it again.

This will avoid that step and allow greater flexibily for providers to handle their own serialization.

Alternatives considered:
* Unexporting `Pepare` and refactoring `Push([]byte)` to `Push([]api.Event)`.