### PR TITLE
Allow use of multiple sink providers

### DIFF
--- a/cmd/app/init.go
+++ b/cmd/app/init.go
@@ -74,27 +74,70 @@ func initConfig(cfgDefault string, envPrefix string) (*koanf.Koanf, error) {
 	return ko, nil
 }
 
-func initSink(ko *koanf.Koanf, log *logrus.Logger) sink.Sink {
-	// Initialise HTTP Provider.
-	http, err := provider.NewHTTP(
-		provider.HTTPOpts{
-			Log:                log,
-			RootURL:            ko.String("sinks.http.root_url"),
-			Timeout:            ko.Duration("sinks.http.timeout"),
-			MaxConnections:     ko.Int("sinks.http.max_idle_conns"),
-			HealthCheckEnabled: ko.Bool("sinks.http.healthcheck.enabled"),
-			HealthcheckURL:     ko.String("sinks.http.healthcheck.url"),
-			HealthCheckStatus:  ko.Int("sinks.http.healthcheck.status"),
-		})
-	if err != nil {
-		log.WithError(err).Fatal("error initialising http sink provider")
+func initProviders(ko *koanf.Koanf, log *logrus.Logger) (providers []provider.Provider, err error) {
+	// Initialise HTTP Providers.
+	if ko.Exists("http") {
+		// Check for legacy sinks.http.root_url key
+		if ko.Exists("http.root_url") {
+			// Fallback to legacy single provider
+			log.Warning("initializing legacy http provider. Move `[sinks.http] to `[sinks.http.default]`")
+			log.Warning("only a single sink provider is supported with legacy configuration")
+			httpConf := ko.Cut("http")
+
+			options := provider.ParseHTTPOpts(httpConf)
+			options.Log = log
+
+			var http *provider.HTTPManager
+			http, err = provider.NewHTTP(options)
+			if err != nil {
+				err = fmt.Errorf("error initializing legacy provider: %w", err)
+				return
+			}
+
+			providers = append(providers, http)
+
+			// NOTE: does not parse any additional providers. To use multiple providers one must migrate.
+			return
+		}
+
+		for _, httpProvider := range ko.MapKeys("http") {
+			log.Debugf("initializing http provider %s", httpProvider)
+			httpConf := ko.Cut("http." + httpProvider)
+
+			options := provider.ParseHTTPOpts(httpConf)
+			options.Log = log
+
+			var http *provider.HTTPManager
+			http, err = provider.NewHTTP(options)
+			if err != nil {
+				err = fmt.Errorf("error initializing provider %s: %w", httpProvider, err)
+				return
+			}
+
+			providers = append(providers, http)
+		}
 	}
 
-	sink := sink.New([]provider.Provider{http}, sink.Opts{
-		BatchWorkers:     ko.Int("sinks.batch.workers"),
-		BatchQueueSize:   ko.Int("sinks.batch.queue_size"),
-		BatchIdleTimeout: ko.Duration("sinks.batch.idle_timeout"),
-		BatchEventsCount: ko.Int("sinks.batch.events_count"),
+	return
+}
+
+func initSink(ko *koanf.Koanf, log *logrus.Logger) sink.Sink {
+	providers, err := initProviders(ko.Cut("sinks"), log)
+	if err != nil {
+		log.WithError(err).Fatal("error initializing providers")
+	}
+
+	var sinkConfig = ko.Cut("sinks")
+	if sinkConfig.Exists("batch") {
+		// Use legacy batch config
+		log.Warning("using legacy sink batch config. Move `[sinks.batch]` under `[sinks]`")
+		sinkConfig = ko.Cut("batch")
+	}
+	sink := sink.New(providers, sink.Opts{
+		BatchWorkers:     sinkConfig.Int("workers"),
+		BatchQueueSize:   sinkConfig.Int("queue_size"),
+		BatchIdleTimeout: sinkConfig.Duration("idle_timeout"),
+		BatchEventsCount: sinkConfig.Int("events_count"),
 		Log:              log,
 	})
 	if err != nil {

--- a/config.sample.toml
+++ b/config.sample.toml
@@ -8,18 +8,17 @@ topics = ["Deployment", "Allocation", "Evaluation", "Job", "Node"] # Topics to s
 max_reconnect_attempts = 5 # Maximum reconnection attempts with Nomad Events API. After this limit is breached, program exits.
 
 [sinks]
-[sinks.batch]
 workers = 10 # Number of background workers to process events.
 queue_size = 100 # Max number of events each sink channel can store.
 idle_timeout = "5s" # If a batch is in memory for more than `idle_timeout` duration, it is flushed to providers.
 events_count = 5 # If a batch has more events than `events_counts`, it is flushed to providers.
 
-[sinks.http]
+[sinks.http.default]
 root_url = "http://localhost:3333" # HTTP server URL to `POST` events data to.
 timeout = "7s" # Timeout for the ingestion request.
 max_idle_conns = 100 # Number of keep-alive connections to keep in pool.
 
-[sinks.http.healthcheck]
+[sinks.http.default.healthcheck]
 enabled = false # Abort if the upstream is unhealthy. This check is performed only during start of program.
 url = "http://localhost:3333" # Ping endpoint for the HTTP provider.
 status = 405 # Status code to mark as healthy.

--- a/internal/sinks/provider/http.go
+++ b/internal/sinks/provider/http.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/knadh/koanf"
 	"github.com/sirupsen/logrus"
 )
 
@@ -25,6 +26,17 @@ type HTTPOpts struct {
 	HealthCheckEnabled bool
 	HealthcheckURL     string
 	HealthCheckStatus  int
+}
+
+func ParseHTTPOpts(ko *koanf.Koanf) HTTPOpts {
+	return HTTPOpts{
+		RootURL:            ko.String("root_url"),
+		Timeout:            ko.Duration("timeout"),
+		MaxConnections:     ko.Int("max_idle_conns"),
+		HealthCheckEnabled: ko.Bool("healthcheck.enabled"),
+		HealthcheckURL:     ko.String("healthcheck.url"),
+		HealthCheckStatus:  ko.Int("healthcheck.status"),
+	}
 }
 
 // NewHTTP initializes a HTTP notification dispatcher object.


### PR DESCRIPTION
This will open up the ability to specify multiple sink destinations.

This also makes it possible to add different types of providers, eg. `[sink.loki.main]`.