### PR TITLE
Make sink healthcheck more flexible for providers

### DIFF
--- a/internal/sinks/provider/provider.go
+++ b/internal/sinks/provider/provider.go
@@ -5,6 +5,6 @@ type Provider interface {
 	Name() string
 	// Push pushes a batch of event to upstream. The implementation varies across providers.
 	Push([]byte) error
-	// Ping implements a healthcheck.
-	Ping(url string, status int) error
+	// HealthCheck implements a healthcheck.
+	HealthCheck() error
 }


### PR DESCRIPTION
The `Ping(...)` method was opinionated for the http provider. This refactor makes it a bit more agnostic allowing new providers to customize the funcatinality and renaming it `HealthCheck()` to be more agnostic as well.

Alternatives considered:
* Removing `Ping()` from the `Provider` interface entirely since it is not not used outside of the provider's New function. I left it in place to allow future periodic healthchecks.